### PR TITLE
📝 update(types): use float32 for coins

### DIFF
--- a/types.go
+++ b/types.go
@@ -2048,7 +2048,7 @@ type UserInfo struct {
 	// 只能查看自己的
 	//
 	// 默认为0
-	Coins     int  `json:"coins"`
+	Coins     float32  `json:"coins"`
 	FansBadge bool `json:"fans_badge"` // 是否具有粉丝勋章 false：无 true：有
 	Official  struct {
 		// 认证类型


### PR DESCRIPTION
调用UserGetInfo()时，发生如下错误：  

> json: cannot unmarshal number 44.3 into Go struct fiel
d UserInfo.coins of type int

显示我有44.3个硬币，硬币是有小数的，这里应该用`float32`作为Coins的类型。